### PR TITLE
Suppress notification sound on Alt+T.

### DIFF
--- a/src/textassist.c
+++ b/src/textassist.c
@@ -983,6 +983,8 @@ static LRESULT WINAPI subclassed_edit_control_window_proc(
         return 0;
       }
     } else if (wparam == 0x54) {
+      MSG msg;
+      while (PeekMessageW(&msg, hwnd, WM_SYSCHAR, WM_SYSCHAR, PM_REMOVE));
       if (insert_tag(hwnd)) {
         UpdateWindow(hwnd);
         SendMessageW(g_exedit_window, WM_COMMAND, (WPARAM)(MAKELONG(GetDlgCtrlID(hwnd), EN_CHANGE)), (LPARAM)hwnd);


### PR DESCRIPTION
環境にもよるかもしれず他の環境ではテストできてませんが，Alt+Tで通知音が鳴っていたのを抑制できたので提案します．

Alt+Tで発生する `WM_SYSKEYDOWN` メッセージのときに `PeekMessage()` 関数で `WM_SYSCHAR` メッセージを削除すると通知音が鳴らなくなりました．

#3 とは打って変わって文書化された仕様が見つからず，これが正しい方法なのかわからないため別案件としてPull Requestしました．