### PR TITLE
フォントリストの上下キーでの順送り方向を反転など．

### DIFF
--- a/src/textassist.c
+++ b/src/textassist.c
@@ -430,9 +430,10 @@ static struct font_list g_font_name_list = {0};
 
 static PCWSTR choice_similar_font(struct font_list *fl, HWND hwnd, PCWSTR s) {
   DWORD caret_start = 0, caret_end = 0;
+  SendMessageW(hwnd, EM_SCROLLCARET, 0, 0);
   SendMessageW(hwnd, EM_GETSEL, (WPARAM)&caret_start, (LPARAM)&caret_end);
   LRESULT r = SendMessageW(hwnd, EM_POSFROMCHAR, (WPARAM)caret_start, 0);
-  POINT pt = {LOWORD(r), HIWORD(r)};
+  POINT pt = {(int)(short)LOWORD(r), (int)(short)HIWORD(r)};
   if (!ClientToScreen(hwnd, &pt)) {
     ods(L"ClientToScreen failed");
     return NULL;
@@ -484,7 +485,7 @@ static bool increment_tag_font(HWND hwnd, struct tag *tag, int const pos, int co
   case 1: {
     int const fidx = font_list_index_of(&g_font_name_list, tag->value.font.name);
     if (fidx != -1) {
-      int const v = choice_by_arrow_up_downi(keyCode, 1, -1, 10, -10);
+      int const v = choice_by_arrow_up_downi(keyCode, -1, 1, -10, 10);
       if (!v) {
         return false;
       }
@@ -500,7 +501,7 @@ static bool increment_tag_font(HWND hwnd, struct tag *tag, int const pos, int co
   }
     return true;
   case 2: {
-    int const v = choice_by_arrow_up_downi(keyCode, 1, -1, 1, -1);
+    int const v = choice_by_arrow_up_downi(keyCode, -1, 1, -1, 1);
     if (!v) {
       return false;
     }
@@ -615,7 +616,7 @@ static int sprint_tag_position(wchar_t *buf, struct tag *tag) {
       buf[0] = L'\0';
       return 0;
     }
-    return wsprintfW(buf, L"<p%s,%s>", x, y, z);
+    return wsprintfW(buf, L"<p%s,%s>", x, y);
   }
   return -1;
 }
@@ -698,9 +699,10 @@ static wchar_t *get_text_from_window(HWND hwnd, int *length) {
 
 static bool insert_tag(HWND hwnd) {
   DWORD caret_start = 0, caret_end = 0;
+  SendMessageW(hwnd, EM_SCROLLCARET, 0, 0);
   SendMessageW(hwnd, EM_GETSEL, (WPARAM)&caret_start, (LPARAM)&caret_end);
   LRESULT r = SendMessageW(hwnd, EM_POSFROMCHAR, (WPARAM)caret_end, 0);
-  POINT pt = {LOWORD(r), HIWORD(r)};
+  POINT pt = {(int)(short)LOWORD(r), (int)(short)HIWORD(r)};
   if ((uint32_t)r == 0xffffffff) {
     // Move the caret to the end of the selection
     SendMessageW(hwnd, EM_SETSEL, (WPARAM)caret_start, (LPARAM)caret_end);


### PR DESCRIPTION
1. フォントリストの上下キーでの順送り方向を反転．`BI` 部分も同様に反転．
2. カーソル座標取得時のオーバーフロー修正．
3. メニュー出現時，カレット位置にスクロールするよう変更．
4. 動作には影響しないが `wsprintfW()` で引数が過多だったのを削除．

以下詳細です．

1. 自身のプラグインデバッグ時，`<s,,>` タグで Alt+上下キー でフォントを順送りしていくと，上キーで後ろの候補 / 下キーで最初のほうの候補が出てくることに気付きました．フォントのドロップダウンリストの順序と逆なので分かりにくいと思い反転しました．

   ついでに太文字やイタリックをコントロールする部分も同様に反転しました．こちらはまだ不自然さは少ないかもしれませんが．

2. 現在のカレット位置がテキストボックスのスクロールで上のほうに見切れている状態で Alt+T を入力すると画面の一番下にメニューが表示されていました．

   これは `EM_POSFROMCHAR` の戻り値を座標に変換する際にオーバーフローが起きていたのが原因でした．[MSの文書](https://learn.microsoft.com/en-us/windows/win32/controls/em-posfromchar)でも `HIWORD`, `LOWORD` マクロを引き合いに出しているのもタチが悪いと思いますが，[`WM_LBUTTONDOWN`](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-lbuttondown) などのページだと，`HIWORD` や `LOWORD` を使わずに `GET_X_LPARAM` と `GET_Y_LPARAM` を使うように書かれています．（`windowsx.h` の追加インクルードが必要．）

   ```c
   #define GET_X_LPARAM(lp)  ((int)(short)LOWORD(lp))
   #define GET_Y_LPARAM(lp)  ((int)(short)HIWORD(lp))
   ```

   この展開結果をそのまま使う形のコードに修正しました．

3. そもそもメニュー出現位置がスクロール外なのも使いにくいとも思いました．なので位置取得の直前にカレット位置までスクロールさせるメッセージ送信を挿入しました，

   (2) の修正がなくてもオーバーフローの可能性は低くなりましたが，それでもまだ選択範囲の変な取り方をすればスクロール範囲外の座標を返してオーバーフローする可能性があるため，(2) との併用が良いと思います．

4. `wsprintfW(buf, L"<p%s,%s>", x, y, z);` とあった部分で，`z` が使われていなかったので削除しました．VSコンパイラで警告が出ていたので．

以上です．ご確認お願いします．
